### PR TITLE
add getRedirectUrl method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ public function request(Zarinpal $zarinpal) {
 ...
 ```
 
+If you have other redirection methods you can use:
+```php
+$zarinpal->getRedirectUrl($authority)
+```
+to get the redirect url as a string.
+
+
 **verify the payment:**
 
 ```php

--- a/src/Zarinpal.php
+++ b/src/Zarinpal.php
@@ -151,6 +151,19 @@ class Zarinpal
     }
 
     /**
+     * Get generated redirect url
+     *
+     * @param  string $authority
+     *
+     * @return void
+     */
+    public function getRedirectUrl($authority)
+    {
+        $sub = ($this->sandbox) ? 'sandbox' : 'www';
+        return 'https://'.$sub.'.zarinpal.com/pg/StartPay/'.$authority;
+    }
+
+    /**
      * Redirect to payment page.
      *
      * @param  string $authority
@@ -159,8 +172,7 @@ class Zarinpal
      */
     public function redirect($authority)
     {
-        $sub = ($this->sandbox) ? 'sandbox' : 'www';
-        $url = 'https://'.$sub.'.zarinpal.com/pg/StartPay/'.$authority;
+        $url = $this->getRedirectUrl($authority);
         header('Location: '.$url);
         exit;
     }


### PR DESCRIPTION
In REST Full APIs we can't redirect requests directly and we need to get redirect url and pass it to our client. I added a method that returns the redirect url.