### PR TITLE
Replace deprecated curly braces syntax in PHP

### DIFF
--- a/src/Clients/GuzzleClient.php
+++ b/src/Clients/GuzzleClient.php
@@ -31,7 +31,7 @@ class GuzzleClient implements IClient
         $client = new Client([
             'base_uri' => $this->baseUrl
         ]);
-        $response = $client->request('POST', "${method}.json", [
+        $response = $client->request('POST', "{$method}.json", [
             'headers' => array_merge([
                 'user-agent' => 'ZarinPal Rest Api v4',
                 'cache-control' => 'no-cache',

--- a/src/Zarinpal.php
+++ b/src/Zarinpal.php
@@ -112,7 +112,7 @@ class Zarinpal
         return $this->client->sendRequest('unVerified', array_merge([
             'merchant_id' => $this->merchantID
         ], $payload), [
-            'authorization' => "Bearer ${accessToken}"
+            'authorization' => "Bearer {$accessToken}"
         ]);
     }
 


### PR DESCRIPTION
The curly braces syntax for accessing array elements and string offsets has been deprecated in PHP. This commit replaces all instances of the deprecated syntax with the recommended square bracket syntax.